### PR TITLE
Fix Zod Validation Error for `question` in `humanAssistanceRequests

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,9 @@ export const doTaskActionSchema = z
               .nullish()
               .openapi({ description: "Human's response to the question" }),
             id: z.number(),
-            question: z.string().openapi({ description: "Agent's question for the user" }),
+            question: z
+              .union([z.string(), z.record(z.any())])
+              .openapi({ description: "Agent's question for the user" }),
             status: z.enum(['pending', 'responded']),
             type: z.enum(['text', 'project-manager-plan-review']).openapi({
               description:

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -251,6 +251,30 @@ describe('Agent API Methods', () => {
     assert.deepStrictEqual(result, { success: true })
   })
 
+  test('should handle human assistance operations with question in object format', async () => {
+    const agent = new Agent({
+      apiKey: mockApiKey,
+      systemPrompt: 'You are a test agent'
+    })
+
+    // Mock the API client
+    Object.defineProperty(agent, 'apiClient', {
+      value: {
+        post: async () => ({ data: { success: true } })
+      },
+      writable: true
+    })
+
+    const result = await agent.requestHumanAssistance({
+      workspaceId: 1,
+      taskId: 1,
+      type: 'text',
+      question: { question: 'Need help' }
+    })
+
+    assert.deepStrictEqual(result, { success: true })
+  })
+
   test('should handle server lifecycle', async () => {
     const agent = new TestAgent({
       apiKey: mockApiKey,


### PR DESCRIPTION
## Description  
This PR fixes a `ZodError` occurring in the `actionSchema` when handling human assistance requests.

## Problem  
When a user responds to a `humanAssistanceRequests` from the platform, the `question` field sometimes contains an **object instead of a string**, leading to a validation error:

```json
{
  "error": {
    "issues": [
      {
        "code": "invalid_type",
        "expected": "string",
        "received": "object",
        "path": ["task", "humanAssistanceRequests", 0, "question"],
        "message": "Expected string, received object"
      }
    ],
    "name": "ZodError"
  }
}
```

## Solution  
To fix this, I updated the schema definition to allow both **strings** and **objects** for `question` in `humanAssistanceRequests`. This ensures the agent can process both formats without failing due to strict type validation.

## Changes  
- Updated `actionSchema` to support both `string` and `object` types for `question`.  
- Used `z.union([z.string(), z.record(z.any())])` to handle both cases.  

## Impact  
- Prevents unexpected crashes due to Zod validation failures.  
- Allows more flexibility in handling different formats for `question`.  
- Improves overall robustness of the agent when processing human assistance requests.  

Let me know if any additional changes are needed! 🚀  

