### PR TITLE
Add getSecrets() and getSecretValue() methods with types and tests

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -9,6 +9,8 @@ import { logger } from './logger'
 import type http from 'node:http'
 import type {
   GetFilesParams,
+  GetSecretsParams,
+  GetSecretValueParams,
   UploadFileParams,
   MarkTaskAsErroredParams,
   CompleteTaskParams,
@@ -317,6 +319,30 @@ export class Agent {
    */
   async getFiles(params: GetFilesParams) {
     const response = await this.apiClient.get(`/workspaces/${params.workspaceId}/files`)
+    return response.data
+  }
+
+  /**
+   * Get all secrets for an agent in a workspace.
+   *
+   * @param {GetSecretsParams} params - Parameters for the secrets retrieval
+   * @returns {Promise<any>} List of agent secrets.
+   */
+  async getSecrets(params: GetSecretsParams) {
+    const response = await this.apiClient.get(`/workspaces/${params.workspaceId}/agent-secrets`)
+    return response.data
+  }
+
+  /**
+   * Get the value of a secret for an agent in a workspace
+   *
+   * @param {GetSecretValueParams} params - Parameters for the secret value retrieval
+   * @returns {Promise<string>} The value of the secret.
+   */
+  async getSecretValue(params: GetSecretValueParams): Promise<string> {
+    const response = await this.apiClient.get(
+      `/workspaces/${params.workspaceId}/agent-secrets/${params.secretId}/value`
+    )
     return response.data
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,14 @@ export interface GetFilesParams {
   workspaceId: number
 }
 
+export interface GetSecretsParams {
+  workspaceId: number
+}
+export interface GetSecretValueParams {
+  workspaceId: number
+  secretId: number
+}
+
 export const getFilesParamsSchema = z.object({
   workspaceId: z.number().int().positive()
 })

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -434,6 +434,56 @@ describe('Agent File Operations', () => {
     })
     assert.deepStrictEqual(uploadResult, { fileId: 'test-file-id' })
   })
+
+  test('should get secrets collection', async () => {
+    const agent = new Agent({
+      apiKey: mockApiKey,
+      systemPrompt: 'You are a test agent'
+    })
+
+    const mockSecretCollection = [
+      {
+        id: 1,
+        name: 'My secret'
+      }
+    ]
+
+    // Mock the API client
+    Object.defineProperty(agent, 'apiClient', {
+      value: {
+        get: async () => ({ data: mockSecretCollection })
+      },
+      writable: true
+    })
+
+    const secretCollection = await agent.getSecrets({
+      workspaceId: 1
+    })
+    assert.deepStrictEqual(secretCollection, mockSecretCollection)
+  })
+
+  test('should get revealed secret value', async () => {
+    const agent = new Agent({
+      apiKey: mockApiKey,
+      systemPrompt: 'You are a test agent'
+    })
+
+    const mockSecretRevealedalue = 'MyRevealedSecretValue'
+
+    // Mock the API client
+    Object.defineProperty(agent, 'apiClient', {
+      value: {
+        get: async () => ({ data: mockSecretRevealedalue })
+      },
+      writable: true
+    })
+
+    const secretValue = await agent.getSecretValue({
+      workspaceId: 1,
+      secretId: 1
+    })
+    assert.deepStrictEqual(secretValue, mockSecretRevealedalue)
+  })
 })
 
 describe('Agent Task Operations', () => {


### PR DESCRIPTION
## Description
This PR introduces two new methods, `getSecrets()` and `getSecretValue()`, to handle secret management.  
Both methods are fully typed to ensure type safety and maintainability. Additionally, comprehensive tests have been added to validate their functionality.

## Changes
- Added `getSecrets()` method to retrieve all secrets.
- Added `getSecretValue()` method to fetch a specific secret.
- Implemented proper TypeScript types for both methods.
- Added unit tests to cover different use cases.

## Notes
- Ensure to review the test cases for expected behaviors.
- Let me know if any additional refinements are needed.