### PR TITLE
Make the current SDK compatible with latest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ const files = await agent.getFiles({
 
 ```typescript
 const task = await agent.createTask({
-  workspaceId: number,
+  workspaceId: number | string,
   assignee: number,
   description: string,
   body: string,
@@ -464,8 +464,8 @@ const task = await agent.createTask({
 
 ```typescript
 await agent.updateTaskStatus({
-  workspaceId: number,
-  taskId: number,
+  workspaceId: number | string,
+  taskId: number | string,
   status: 'to-do' | 'in-progress' | 'human-assistance-required' | 'error' | 'done' | 'cancelled'
 })
 ```
@@ -474,8 +474,8 @@ await agent.updateTaskStatus({
 
 ```typescript
 await agent.addLogToTask({
-  workspaceId: number,
-  taskId: number,
+  workspaceId: number | string,
+  taskId: number | string,
   severity: 'info' | 'warning' | 'error',
   type: 'text' | 'openai-message',
   body: string | object
@@ -488,7 +488,7 @@ await agent.addLogToTask({
 
 ```typescript
 await agent.sendChatMessage({
-  workspaceId: number,
+  workspaceId: number | string,
   agentId: number,
   message: string
 })
@@ -498,8 +498,8 @@ await agent.sendChatMessage({
 
 ```typescript
 await agent.requestHumanAssistance({
-  workspaceId: number,
-  taskId: number,
+  workspaceId: number | string,
+  taskId: number | string,
   type: 'text' | 'project-manager-plan-review',
   question: string | object,
   agentDump?: object
@@ -512,7 +512,7 @@ await agent.requestHumanAssistance({
 
 ```typescript
 const files = await agent.getFiles({
-  workspaceId: number
+  workspaceId: number | string
 })
 ```
 
@@ -520,7 +520,7 @@ const files = await agent.getFiles({
 
 ```typescript
 await agent.uploadFile({
-  workspaceId: number,
+  workspaceId: number | string,
   path: string,
   file: Buffer | string,
   skipSummarizer?: boolean,
@@ -534,7 +534,7 @@ await agent.uploadFile({
 
 ```typescript
 const response = await agent.callIntegration({
-  workspaceId: number,
+  workspaceId: number | string,
   integrationId: string,
   details: {
     endpoint: string,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -913,7 +913,6 @@ export class Agent<M extends string> {
 
       const args = await tool.schema.parseAsync(req.body?.args)
       const messages = req.body.messages || []
-      setActionIdsFromTokens(req.body.action)
       const result = await tool.run.call(this, { args, action: req.body.action }, messages)
       return { result }
     } catch (error) {
@@ -1121,17 +1120,6 @@ export class Agent<M extends string> {
           }
         }
       })
-    }
-  }
-}
-
-function setActionIdsFromTokens(action: any) {
-  if (action) {
-    if (action.task && action.taskUpdateToken) {
-      action.task.id = action.taskUpdateToken
-    }
-    if (action.workspace && action.workspaceUpdateToken) {
-      action.workspace.id = action.workspaceUpdateToken
     }
   }
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -913,6 +913,7 @@ export class Agent<M extends string> {
 
       const args = await tool.schema.parseAsync(req.body?.args)
       const messages = req.body.messages || []
+      setActionIdsFromTokens(req.body.action)
       const result = await tool.run.call(this, { args, action: req.body.action }, messages)
       return { result }
     } catch (error) {
@@ -1120,6 +1121,17 @@ export class Agent<M extends string> {
           }
         }
       })
+    }
+  }
+}
+
+function setActionIdsFromTokens(action: any) {
+  if (action) {
+    if (action.task && action.taskUpdateToken) {
+      action.task.id = action.taskUpdateToken
+    }
+    if (action.workspace && action.workspaceUpdateToken) {
+      action.workspace.id = action.workspaceUpdateToken
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,7 +348,7 @@ export const respondChatMessageActionSchema = z
       })
     ),
     workspace: z.object({
-      id: z.number(),
+      id: z.union([z.number(), z.string()]),
       goal: z.string(),
       bucket_folder: z.string(),
       latest_workspace_execution_status: z

--- a/src/types.ts
+++ b/src/types.ts
@@ -465,10 +465,6 @@ export interface GetSecretValueParams {
 
 export type GetSecretValueResponse = string
 
-export const getFilesParamsSchema = z.object({
-  workspaceId: z.number().int().positive()
-})
-
 export interface UploadFileParams {
   workspaceId: WorkspaceId
   path: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -434,8 +434,11 @@ const agentChatMessagesResponseSchema = z.object({
 
 export type AgentChatMessagesResponse = z.infer<typeof agentChatMessagesResponseSchema>
 
+type WorkspaceId = string | number
+type TaskId = string | number
+
 export interface GetFilesParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId | string
 }
 
 export type GetFilesResponse = {
@@ -447,7 +450,7 @@ export type GetFilesResponse = {
 }[]
 
 export interface GetSecretsParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
 }
 
 export type GetSecretsResponse = {
@@ -456,7 +459,7 @@ export type GetSecretsResponse = {
 }[]
 
 export interface GetSecretValueParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
   secretId: number
 }
 
@@ -467,9 +470,9 @@ export const getFilesParamsSchema = z.object({
 })
 
 export interface UploadFileParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
   path: string
-  taskIds?: number[] | number | null
+  taskIds?: TaskId[] | TaskId | null
   skipSummarizer?: boolean
   file: Buffer | string
 }
@@ -481,7 +484,7 @@ export type UploadFileResponse = {
 }
 
 export interface DeleteFileParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
   fileId: number
 }
 
@@ -490,23 +493,23 @@ export type DeleteFileResponse = {
 }
 
 export interface MarkTaskAsErroredParams {
-  workspaceId: number | string
-  taskId: number | string
+  workspaceId: WorkspaceId
+  taskId: TaskId
   error: string
 }
 
 export type MarkTaskAsErroredResponse = undefined
 
 export interface CompleteTaskParams {
-  workspaceId: number | string
-  taskId: number | string
+  workspaceId: WorkspaceId
+  taskId: TaskId
   output: string
 }
 
 export type CompleteTaskResponse = undefined
 
 export interface SendChatMessageParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
   agentId: number
   message: string
 }
@@ -514,8 +517,8 @@ export interface SendChatMessageParams {
 export type SendChatMessageResponse = undefined
 
 export interface GetTaskDetailParams {
-  workspaceId: number | string
-  taskId: number | string
+  workspaceId: WorkspaceId
+  taskId: TaskId
 }
 
 export type GetTaskDetailResponse = {
@@ -539,7 +542,7 @@ export type GetTaskDetailResponse = {
 }
 
 export interface GetAgentsParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
 }
 
 export type GetAgentsResponse = {
@@ -549,12 +552,12 @@ export type GetAgentsResponse = {
 }[]
 
 export interface GetChatMessagesParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
   agentId: number
 }
 
 export interface GetTasksParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
 }
 
 export type GetTasksResponse = {
@@ -569,7 +572,7 @@ export type GetTasksResponse = {
 }[]
 
 export interface CreateTaskParams {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
   assignee: number
   description: string
   body: string
@@ -583,8 +586,8 @@ export type CreateTaskResponse = {
 }
 
 export interface AddLogToTaskParams {
-  workspaceId: number | string
-  taskId: number | string
+  workspaceId: WorkspaceId
+  taskId: TaskId
   severity: 'info' | 'warning' | 'error'
   type: 'text' | 'openai-message'
   body: string | object
@@ -593,8 +596,8 @@ export interface AddLogToTaskParams {
 export type AddLogToTaskResponse = undefined
 
 export interface RequestHumanAssistanceParams {
-  workspaceId: number | string
-  taskId: number | string
+  workspaceId: WorkspaceId
+  taskId: TaskId
   type: 'text' | 'project-manager-plan-review'
   question: string | object
   agentDump?: object
@@ -603,8 +606,8 @@ export interface RequestHumanAssistanceParams {
 export type RequestHumanAssistanceResponse = undefined
 
 export interface UpdateTaskStatusParams {
-  workspaceId: number | string
-  taskId: number | string
+  workspaceId: WorkspaceId
+  taskId: TaskId
   status: TaskStatus
 }
 
@@ -630,7 +633,7 @@ export interface ProxyConfiguration {
 }
 
 export interface IntegrationCallRequest {
-  workspaceId: number | string
+  workspaceId: WorkspaceId
   integrationId: string
   details: ProxyConfiguration
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,81 @@ export const taskStatusSchema = z
 
 export type TaskStatus = z.infer<typeof taskStatusSchema>
 
+const triggerEventPayloadWithSummarySchema = z.object({
+  event: z.unknown(),
+  summary: z.string()
+})
+
+export const chatMessageArtifacts = z.array(
+  z.intersection(
+    z.object({
+      id: z.string()
+    }),
+    z.discriminatedUnion('type', [
+      z
+        .object({
+          type: z.literal('json'),
+          data: z.record(z.string(), z.unknown())
+        })
+        .openapi({
+          description:
+            "type is 'json' and the data is a JSON object. This is what your agents will typically use."
+        }),
+      z
+        .object({
+          type: z.literal('artifact-card'),
+          data: z.unknown()
+        })
+        .openapi({
+          description:
+            "type is 'artifact-card' and the data is a JSON object. This is what your users will typically use to respond to the agent's artifact."
+        }),
+      z
+        .object({
+          type: z.literal('artifact-card-response'),
+          artifactId: z.string(),
+          data: z.unknown().nullish()
+        })
+        .openapi({
+          description:
+            "type is 'artifact-card-response' and the artifactId is the id of the artifact that the user responded to."
+        })
+    ])
+  )
+)
+
+export const chatMessageParts = z.object({
+  artifacts: chatMessageArtifacts
+})
+
+const integrationConnectionSchema = z.object({
+  id: z.string(),
+  type: z.enum(['nango', 'custom', 'internal']),
+  identifier: z.string(),
+  name: z.string(),
+  description: z.string(),
+  scopes: z.array(z.string()),
+  connectionName: z.string()
+})
+
+const mcpServersSchema = z.array(
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().nullish(),
+    url: z.string(),
+    headers: z.record(z.string(), z.string()).nullish(),
+    transport: z.enum(['http', 'sse']),
+    tools: z.array(
+      z.object({
+        name: z.string(),
+        description: z.string().nullish(),
+        inputSchema: z.any()
+      })
+    )
+  })
+)
+
 const projectManagerPlanReviewHumanAssistanceQuestionSchema = z.object({
   tasks: z.array(
     z.object({
@@ -66,6 +141,68 @@ const baseHumanAssistanceRequestSchema = z.discriminatedUnion('type', [
 export const doTaskActionSchema = z
   .object({
     type: z.literal('do-task'),
+    workspaceUpdateToken: z.string().nullish(),
+    taskUpdateToken: z.string().nullish(),
+    explicitInput: z.unknown().nullish(),
+    triggerEvents: z.array(
+      z.object({
+        name: z.string(),
+        description: z.string().nullish(),
+        integrationName: z.string().nullish(),
+        integrationType: z.enum(['nango', 'custom', 'internal']),
+        trigger_name: z.string().nullish(),
+        payload: z.array(triggerEventPayloadWithSummarySchema)
+      })
+    ),
+    sessionHistory: z
+      .array(
+        z.object({
+          tasks: z.array(
+            z.object({
+              id: z.number().openapi({ description: 'The ID of the task' }),
+              description: z.string().openapi({
+                description:
+                  "Short description of the task. Usually in the format of 'Do [something]'"
+              }),
+              body: z.string().nullish().openapi({
+                description:
+                  'Additional task information or data. Usually 2-3 sentences if available.'
+              }),
+              expectedOutput: z
+                .string()
+                .nullish()
+                .openapi({ description: 'Preferred output of the task' }),
+              input: z.string().nullish().openapi({
+                description:
+                  "The input information for the task. Typically, it's an output of another task."
+              }),
+              output: z.string().nullish().openapi({
+                description: 'The output of the task. This is the result of the task.'
+              })
+            })
+          ),
+          triggerEvents: z
+            .array(
+              z.object({
+                name: z.string(),
+                description: z.string().nullish(),
+                integrationName: z.string().nullish(),
+                integrationType: z.enum(['nango', 'custom', 'internal']),
+                trigger_name: z.string().nullish(),
+                payload: z.array(triggerEventPayloadWithSummarySchema)
+              })
+            )
+            .openapi({
+              description:
+                'The optional payload of the trigger that triggered the task execution for a session'
+            })
+        })
+      )
+      .optional()
+      .openapi({
+        description:
+          'The optional payload of the trigger that triggered the task execution for a session'
+      }),
     me: z
       .intersection(
         z.object({
@@ -89,7 +226,7 @@ export const doTaskActionSchema = z
       )
       .openapi({ description: 'Your agent instance' }),
     task: z.object({
-      id: z.number().openapi({ description: 'The ID of the task' }),
+      id: z.union([z.number(), z.string()]).openapi({ description: 'The ID of the task' }),
       description: z.string().openapi({
         description: "Short description of the task. Usually in the format of 'Do [something]'"
       }),
@@ -139,15 +276,29 @@ export const doTaskActionSchema = z
         )
       )
     }),
+    triggerEvent: z
+      .object({
+        name: z.string(),
+        description: z.string().nullish(),
+        integrationName: z.string().nullish(),
+        integrationType: z.enum(['nango', 'custom', 'internal']),
+        trigger_name: z.string().nullish(),
+        payload: z.array(triggerEventPayloadWithSummarySchema)
+      })
+      .optional()
+      .openapi({
+        description: 'The optional payload of the trigger that triggered the task execution'
+      }),
     workspace: z.object({
-      id: z.number(),
+      id: z.union([z.number(), z.string()]),
       goal: z.string(),
       bucket_folder: z.string(),
       agents: z.array(
         z.object({
           id: z.number(),
           name: z.string(),
-          capabilities_description: z.string()
+          capabilities_description: z.string(),
+          integrations: z.array(integrationConnectionSchema).optional()
         })
       )
     }),
@@ -167,6 +318,16 @@ export const doTaskActionSchema = z
         })
       })
     ),
+    mcpServers: mcpServersSchema.optional(),
+    agentKnowledgeFiles: z
+      .array(
+        z.object({
+          id: z.number(),
+          path: z.string(),
+          state: z.enum(['pending', 'processing', 'processed', 'error', 'skipped'])
+        })
+      )
+      .optional(),
     memories: z.array(
       z.object({
         id: z.number(),
@@ -180,12 +341,13 @@ export const doTaskActionSchema = z
 export const respondChatMessageActionSchema = z
   .object({
     type: z.literal('respond-chat-message'),
-    workspaceExecutionId: z.number().optional(),
+    workspaceUpdateToken: z.string().nullish(),
     me: z.intersection(
       z.object({
         id: z.number(),
+        uid: z.string().optional(),
         name: z.string(),
-        kind: agentKind
+        kind: z.enum(['external', 'eliza', 'openserv'])
       }),
       z.discriminatedUnion('isBuiltByAgentBuilder', [
         z.object({
@@ -202,36 +364,44 @@ export const respondChatMessageActionSchema = z
         author: z.enum(['agent', 'user']),
         createdAt: z.coerce.date(),
         id: z.number(),
-        message: z.string()
+        message: z.string(),
+        parts: chatMessageParts
       })
     ),
     workspace: z.object({
-      id: z.number(),
+      id: z.union([z.number(), z.string()]),
       goal: z.string(),
       bucket_folder: z.string(),
+      latest_workspace_execution_status: z.enum([
+        'error',
+        'active',
+        'deleted',
+        'idle',
+        'running',
+        'paused',
+        'completed',
+        'timed-out'
+      ]),
       agents: z.array(
         z.object({
           id: z.number(),
           name: z.string(),
-          capabilities_description: z.string()
+          capabilities_description: z.string(),
+          integrations: z.array(integrationConnectionSchema).optional()
         })
       )
     }),
-    integrations: z.array(
-      z.object({
-        id: z.number(),
-        connection_id: z.string(),
-        provider_config_key: z.string(),
-        provider: z.string(),
-        created: z.string().optional(),
-        metadata: z.record(z.string(), z.unknown()).nullish().optional(),
-        scopes: z.array(z.string()).optional(),
-        openAPI: z.object({
-          title: z.string(),
-          description: z.string()
+    integrations: z.array(integrationConnectionSchema),
+    mcpServers: mcpServersSchema.optional(),
+    agentKnowledgeFiles: z
+      .array(
+        z.object({
+          id: z.number(),
+          path: z.string(),
+          state: z.enum(['pending', 'processing', 'processed', 'error', 'skipped'])
         })
-      })
-    ),
+      )
+      .optional(),
     memories: z.array(
       z.object({
         id: z.number(),
@@ -265,7 +435,7 @@ const agentChatMessagesResponseSchema = z.object({
 export type AgentChatMessagesResponse = z.infer<typeof agentChatMessagesResponseSchema>
 
 export interface GetFilesParams {
-  workspaceId: number
+  workspaceId: number | string
 }
 
 export type GetFilesResponse = {
@@ -277,7 +447,7 @@ export type GetFilesResponse = {
 }[]
 
 export interface GetSecretsParams {
-  workspaceId: number
+  workspaceId: number | string
 }
 
 export type GetSecretsResponse = {
@@ -286,7 +456,7 @@ export type GetSecretsResponse = {
 }[]
 
 export interface GetSecretValueParams {
-  workspaceId: number
+  workspaceId: number | string
   secretId: number
 }
 
@@ -297,7 +467,7 @@ export const getFilesParamsSchema = z.object({
 })
 
 export interface UploadFileParams {
-  workspaceId: number
+  workspaceId: number | string
   path: string
   taskIds?: number[] | number | null
   skipSummarizer?: boolean
@@ -311,7 +481,7 @@ export type UploadFileResponse = {
 }
 
 export interface DeleteFileParams {
-  workspaceId: number
+  workspaceId: number | string
   fileId: number
 }
 
@@ -320,23 +490,23 @@ export type DeleteFileResponse = {
 }
 
 export interface MarkTaskAsErroredParams {
-  workspaceId: number
-  taskId: number
+  workspaceId: number | string
+  taskId: number | string
   error: string
 }
 
 export type MarkTaskAsErroredResponse = undefined
 
 export interface CompleteTaskParams {
-  workspaceId: number
-  taskId: number
+  workspaceId: number | string
+  taskId: number | string
   output: string
 }
 
 export type CompleteTaskResponse = undefined
 
 export interface SendChatMessageParams {
-  workspaceId: number
+  workspaceId: number | string
   agentId: number
   message: string
 }
@@ -344,8 +514,8 @@ export interface SendChatMessageParams {
 export type SendChatMessageResponse = undefined
 
 export interface GetTaskDetailParams {
-  workspaceId: number
-  taskId: number
+  workspaceId: number | string
+  taskId: number | string
 }
 
 export type GetTaskDetailResponse = {
@@ -369,7 +539,7 @@ export type GetTaskDetailResponse = {
 }
 
 export interface GetAgentsParams {
-  workspaceId: number
+  workspaceId: number | string
 }
 
 export type GetAgentsResponse = {
@@ -379,12 +549,12 @@ export type GetAgentsResponse = {
 }[]
 
 export interface GetChatMessagesParams {
-  workspaceId: number
+  workspaceId: number | string
   agentId: number
 }
 
 export interface GetTasksParams {
-  workspaceId: number
+  workspaceId: number | string
 }
 
 export type GetTasksResponse = {
@@ -399,7 +569,7 @@ export type GetTasksResponse = {
 }[]
 
 export interface CreateTaskParams {
-  workspaceId: number
+  workspaceId: number | string
   assignee: number
   description: string
   body: string
@@ -413,8 +583,8 @@ export type CreateTaskResponse = {
 }
 
 export interface AddLogToTaskParams {
-  workspaceId: number
-  taskId: number
+  workspaceId: number | string
+  taskId: number | string
   severity: 'info' | 'warning' | 'error'
   type: 'text' | 'openai-message'
   body: string | object
@@ -423,8 +593,8 @@ export interface AddLogToTaskParams {
 export type AddLogToTaskResponse = undefined
 
 export interface RequestHumanAssistanceParams {
-  workspaceId: number
-  taskId: number
+  workspaceId: number | string
+  taskId: number | string
   type: 'text' | 'project-manager-plan-review'
   question: string | object
   agentDump?: object
@@ -433,8 +603,8 @@ export interface RequestHumanAssistanceParams {
 export type RequestHumanAssistanceResponse = undefined
 
 export interface UpdateTaskStatusParams {
-  workspaceId: number
-  taskId: number
+  workspaceId: number | string
+  taskId: number | string
   status: TaskStatus
 }
 
@@ -460,7 +630,7 @@ export interface ProxyConfiguration {
 }
 
 export interface IntegrationCallRequest {
-  workspaceId: number
+  workspaceId: number | string
   integrationId: string
   details: ProxyConfiguration
 }

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -5,7 +5,6 @@ import {
   doTaskActionSchema,
   respondChatMessageActionSchema,
   UploadFileParams,
-  GetFilesParams,
   MarkTaskAsErroredParams,
   CompleteTaskParams,
   SendChatMessageParams,
@@ -19,7 +18,6 @@ import {
   RequestHumanAssistanceParams,
   UpdateTaskStatusParams,
   ProcessParams,
-  getFilesParamsSchema,
   GetChatMessagesParams
 } from '../src/types'
 
@@ -46,10 +44,23 @@ describe('Action Schemas', () => {
         id: 1,
         goal: 'test goal',
         bucket_folder: 'test-folder',
-        agents: []
+        agents: [],
+        latest_workspace_execution_status: 'active'
       },
-      integrations: [],
-      memories: []
+      integrations: [
+        {
+          id: '1',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope'],
+          connectionName: 'aa'
+        }
+      ],
+      memories: [],
+      triggerEvents: [],
+      sessionHistory: []
     }
 
     const result = doTaskActionSchema.parse(action)
@@ -70,16 +81,28 @@ describe('Action Schemas', () => {
           author: 'user',
           createdAt: new Date(),
           id: 1,
-          message: 'test message'
+          message: 'test message',
+          parts: { artifacts: [] }
         }
       ],
       workspace: {
         id: 1,
         goal: 'test goal',
         bucket_folder: 'test-folder',
-        agents: []
+        agents: [],
+        latest_workspace_execution_status: 'active'
       },
-      integrations: [],
+      integrations: [
+        {
+          id: '1',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope'],
+          connectionName: 'aa'
+        }
+      ],
       memories: []
     }
 
@@ -109,10 +132,23 @@ describe('Action Schemas', () => {
         id: 1,
         goal: 'test goal',
         bucket_folder: 'test-folder',
-        agents: []
+        agents: [],
+        latest_workspace_execution_status: 'active'
       },
-      integrations: [],
-      memories: []
+      integrations: [
+        {
+          id: '1',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope'],
+          connectionName: 'aa'
+        }
+      ],
+      memories: [],
+      triggerEvents: [],
+      sessionHistory: []
     }
 
     const respondChatAction = {
@@ -128,16 +164,28 @@ describe('Action Schemas', () => {
           author: 'user',
           createdAt: new Date(),
           id: 1,
-          message: 'test message'
+          message: 'test message',
+          parts: { artifacts: [] }
         }
       ],
       workspace: {
         id: 1,
         goal: 'test goal',
         bucket_folder: 'test-folder',
-        agents: []
+        agents: [],
+        latest_workspace_execution_status: 'active'
       },
-      integrations: [],
+      integrations: [
+        {
+          id: '1',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope'],
+          connectionName: 'aa'
+        }
+      ],
       memories: []
     }
 
@@ -190,7 +238,8 @@ describe('Action Schemas', () => {
           author: 'invalid-author',
           createdAt: new Date(),
           id: 1,
-          message: 'test message'
+          message: 'test message',
+          parts: { artifacts: [] }
         }
       ]
     }
@@ -251,60 +300,6 @@ describe('Action Schemas', () => {
       file: 'test content'
     }
     assert.ok(params6)
-  })
-
-  test('should validate GetFilesParams', () => {
-    // Test valid case
-    const params: GetFilesParams = {
-      workspaceId: 1
-    }
-    const result = getFilesParamsSchema.parse(params)
-    assert.deepStrictEqual(result, params)
-
-    // Test invalid workspaceId types
-    assert.throws(() => {
-      getFilesParamsSchema.parse({
-        workspaceId: '1'
-      })
-    }, /Expected number, received string/)
-
-    assert.throws(() => {
-      getFilesParamsSchema.parse({
-        workspaceId: null
-      })
-    }, /Expected number, received null/)
-
-    assert.throws(() => {
-      getFilesParamsSchema.parse({
-        workspaceId: undefined
-      })
-    }, /Required/)
-
-    // Test with missing workspaceId
-    assert.throws(() => {
-      getFilesParamsSchema.parse({})
-    }, /Required/)
-
-    // Test with negative workspaceId
-    assert.throws(() => {
-      getFilesParamsSchema.parse({
-        workspaceId: -1
-      })
-    }, /Number must be greater than 0/)
-
-    // Test with zero workspaceId
-    assert.throws(() => {
-      getFilesParamsSchema.parse({
-        workspaceId: 0
-      })
-    }, /Number must be greater than 0/)
-
-    // Test with decimal workspaceId
-    assert.throws(() => {
-      getFilesParamsSchema.parse({
-        workspaceId: 1.5
-      })
-    }, /Expected integer, received float/)
   })
 
   test('should validate MarkTaskAsErroredParams', () => {
@@ -406,10 +401,23 @@ describe('Action Schemas', () => {
         id: 1,
         goal: 'test goal',
         bucket_folder: 'test-folder',
-        agents: []
+        agents: [],
+        latest_workspace_execution_status: 'active'
       },
-      integrations: [],
-      memories: []
+      integrations: [
+        {
+          id: '1',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope'],
+          connectionName: 'aa'
+        }
+      ],
+      memories: [],
+      triggerEvents: [], // here
+      sessionHistory: []
     }
 
     const result = doTaskActionSchema.parse(action)
@@ -556,10 +564,23 @@ describe('Action Schemas', () => {
         id: 1,
         goal: 'test goal',
         bucket_folder: 'test-folder',
-        agents: []
+        agents: [],
+        latest_workspace_execution_status: 'active'
       },
-      integrations: [],
-      memories: []
+      integrations: [
+        {
+          id: '1',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope'],
+          connectionName: 'aa'
+        }
+      ],
+      memories: [],
+      triggerEvents: [],
+      sessionHistory: []
     }
 
     const result = doTaskActionSchema.parse(action)
@@ -638,10 +659,23 @@ describe('Action Schemas', () => {
         id: 1,
         goal: 'test goal',
         bucket_folder: 'test-folder',
-        agents: []
+        agents: [],
+        latest_workspace_execution_status: 'active'
       },
-      integrations: [],
-      memories: []
+      integrations: [
+        {
+          id: '1',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope'],
+          connectionName: 'aa'
+        }
+      ],
+      memories: [],
+      triggerEvents: [],
+      sessionHistory: []
     }
 
     const result = doTaskActionSchema.parse(action)
@@ -680,29 +714,22 @@ describe('Action Schemas', () => {
       },
       integrations: [
         {
-          id: 3,
-          connection_id: 'test-connection',
-          provider_config_key: 'test-provider',
-          provider: 'test',
-          created: '2024-01-01',
-          metadata: { key: 'value' },
-          scopes: ['read', 'write'],
-          openAPI: {
-            title: 'Test API',
-            description: 'Test API description'
-          }
+          id: '3',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope'],
+          connectionName: 'aa'
         },
         {
-          id: 4,
-          connection_id: 'test-connection-2',
-          provider_config_key: 'test-provider-2',
-          provider: 'test-2',
-          created: '2024-01-02',
-          metadata: null,
-          openAPI: {
-            title: 'Test API 2',
-            description: 'Test API description 2'
-          }
+          id: '4',
+          connectionName: 'test-connection-2',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope']
         }
       ],
       memories: [
@@ -711,7 +738,9 @@ describe('Action Schemas', () => {
           memory: 'test memory',
           createdAt: new Date('2024-01-01')
         }
-      ]
+      ],
+      triggerEvents: [],
+      sessionHistory: []
     }
 
     const result = doTaskActionSchema.parse(action)
@@ -733,13 +762,15 @@ describe('Action Schemas', () => {
           author: 'user',
           createdAt: new Date(),
           id: 1,
-          message: 'test message'
+          message: 'test message',
+          parts: { artifacts: [] }
         },
         {
           author: 'agent',
           createdAt: new Date(),
           id: 2,
-          message: 'test response'
+          message: 'test response',
+          parts: { artifacts: [] }
         }
       ],
       workspace: {
@@ -752,21 +783,18 @@ describe('Action Schemas', () => {
             name: 'test agent',
             capabilities_description: 'test capabilities'
           }
-        ]
+        ],
+        latest_workspace_execution_status: 'active'
       },
       integrations: [
         {
-          id: 3,
-          connection_id: 'test-connection',
-          provider_config_key: 'test-provider',
-          provider: 'test',
-          created: '2024-01-01',
-          metadata: { key: 'value' },
-          scopes: ['read', 'write'],
-          openAPI: {
-            title: 'Test API',
-            description: 'Test API description'
-          }
+          id: '3',
+          connectionName: 'test-connection',
+          type: 'custom',
+          identifier: 'abc',
+          name: 'int a',
+          description: 'desc',
+          scopes: ['scope']
         }
       ],
       memories: [


### PR DESCRIPTION
calling `setActionIdsFromTokens(req.body.action)` is required to cover cases when the tool is called by LLM (from the execute endpoint). 

Tests must be updated. 